### PR TITLE
Issue #43 number of ticks per second fixed

### DIFF
--- a/spec/Tolerance/Throttling/Rate/TimeRateSpec.php
+++ b/spec/Tolerance/Throttling/Rate/TimeRateSpec.php
@@ -27,6 +27,6 @@ class TimeRateSpec extends ObjectBehavior
     function it_can_be_constructed_with_minutes()
     {
         $this->beConstructedWith(1, TimeRate::PER_MINUTE);
-        $this->getTicks()->shouldReturn(60);
+        $this->getTicks()->shouldReturn(1/60);
     }
 }

--- a/src/Tolerance/Throttling/Rate/TimeRate.php
+++ b/src/Tolerance/Throttling/Rate/TimeRate.php
@@ -79,6 +79,6 @@ class TimeRate implements Rate
      */
     public function getTicks()
     {
-        return $this->ticks * self::$unitMap[$this->unit];
+        return $this->ticks / self::$unitMap[$this->unit];
     }
 }


### PR DESCRIPTION
This PR fixes issue #43, the bug with `getTicks()` method in `TimeRate` class.