### PR TITLE
Run tests against all lower versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 
 before_script:
   - travis_retry composer install --no-interaction
-  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
+  - if [ "$dependencies" = "lowest" ]; then travis_retry composer update --prefer-lowest --prefer-stable -n; fi;
 
 script:
   - vendor/bin/phpspec run -fpretty -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: php
 
+php:
+  - 5.6
+  - 7.0
+
 matrix:
   include:
     - php: 5.6
-      env: SYMFONY_VERSION='2.8.*'
-    - php: 7.0
-      env: SYMFONY_VERSION='3.0.*'
+      env: dependencies=lowest
 
 sudo: false
 
@@ -15,10 +17,10 @@ cache:
 
 before_install:
   - composer self-update
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update "symfony/symfony:${SYMFONY_VERSION}"; fi;
 
 before_script:
   - travis_retry composer install --no-interaction
+  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
 
 script:
   - vendor/bin/phpspec run -fpretty -v

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
 
     "require-dev": {
-        "phpspec/phpspec": "~2.0",
+        "phpspec/phpspec": "~2.5",
         "behat/behat": "~3.1.0rc1",
         "behat/symfony2-extension": "^2.1",
         "phpunit/phpunit": "^5.1",


### PR DESCRIPTION
Currently Travis runs tests against Symfony 2.8 (lower bound) and 3.0 (upper bound). With this change tests will run against the latest versions (default) and also against all lowest versions of the dependencies (so not just Symfony). I hope it all works fine ;)