### PR TITLE
Support Throwable interface in Exception catchers

### DIFF
--- a/docs/operation-runner/behavioural-runners.rst
+++ b/docs/operation-runner/behavioural-runners.rst
@@ -41,24 +41,24 @@ This runner will retry to run the operation until it is successful or the wait s
     $result = $runner->run($operation);
 
 By default, the retry runner will catch all the exception. If you want to be able to catch only unexpected exceptions
-or only some, you can inject a :code:`ExceptionCatcherVoter` implementation as the third argument
+or only some, you can inject a :code:`ThrowableCatcherVoter` implementation as the third argument
 of the :code:`RetryOperationRunner`. For instance, you can catch every exception but Guzzle's :code:`ClientException` ones.
 
 .. code-block:: php
 
-    use Tolerance\Operation\ExceptionCatcher\ExceptionCatcherVoter;
+    use Tolerance\Operation\ExceptionCatcher\ThrowableCatcherVoter;
 
-    $exceptionCatcherVoter = new class() implements ExceptionCatcherVoter {
-        public function shouldCatch(\Exception $e)
+    $throwableCatcherVoter = new class() implements ThrowableCatcherVoter {
+        public function shouldCatchThrowable(\Throwable $t)
         {
-            return !$e instanceof ClientException;
+            return !$t instanceof ClientException;
         }
     };
 
     $runner = new RetryOperationRunner(
         new CallbackOperationRunner(),
         $waitStrategy,
-        $exceptionCatcherVoter
+        $throwableCatcherVoter
     );
 
 Buffered runner

--- a/spec/Tolerance/Operation/ExceptionCatcher/WildcardExceptionVoterSpec.php
+++ b/spec/Tolerance/Operation/ExceptionCatcher/WildcardExceptionVoterSpec.php
@@ -5,12 +5,14 @@ namespace spec\Tolerance\Operation\ExceptionCatcher;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Tolerance\Operation\ExceptionCatcher\ExceptionCatcherVoter;
+use Tolerance\Operation\ExceptionCatcher\ThrowableCatcherVoter;
 
 class WildcardExceptionVoterSpec extends ObjectBehavior
 {
     function it_is_an_exception_catcher_voter()
     {
         $this->shouldImplement(ExceptionCatcherVoter::class);
+        $this->shouldImplement(ThrowableCatcherVoter::class);
     }
 
     function it_should_catch_any_exception()
@@ -18,5 +20,24 @@ class WildcardExceptionVoterSpec extends ObjectBehavior
         $this->callOnWrappedObject('shouldCatch', [new \RuntimeException()])->shouldReturn(true);
         $this->callOnWrappedObject('shouldCatch', [new \Exception()])->shouldReturn(true);
         $this->callOnWrappedObject('shouldCatch', [new \InvalidArgumentException()])->shouldReturn(true);
+    }
+
+    function it_should_vote_on_any_throwable()
+    {
+        $this->callOnWrappedObject('shouldCatchThrowable', [new \RuntimeException()])->shouldReturn(true);
+        $this->callOnWrappedObject('shouldCatchThrowable', [new \Exception()])->shouldReturn(true);
+        $this->callOnWrappedObject('shouldCatchThrowable', [new \InvalidArgumentException()])->shouldReturn(true);
+
+        // only test this on php >= 7.0
+        if (70000 <= PHP_VERSION_ID) {
+            $this->callOnWrappedObject('shouldCatchThrowable', [new \Error()])->shouldReturn(true);
+        }
+    }
+
+    function it_should_not_vote_on_not_throwables()
+    {
+        $this->callOnWrappedObject('shouldCatchThrowable', ['foo'])->shouldReturn(false);
+        $this->callOnWrappedObject('shouldCatchThrowable', [[]])->shouldReturn(false);
+        $this->callOnWrappedObject('shouldCatchThrowable', [(object) 'foo'])->shouldReturn(false);
     }
 }

--- a/src/Tolerance/Operation/ExceptionCatcher/ExceptionCatcherVoter.php
+++ b/src/Tolerance/Operation/ExceptionCatcher/ExceptionCatcherVoter.php
@@ -11,6 +11,9 @@
 
 namespace Tolerance\Operation\ExceptionCatcher;
 
+/**
+ * @deprecated Use ThrowableCatcherVoter instead
+ */
 interface ExceptionCatcherVoter
 {
     /**
@@ -19,6 +22,7 @@ interface ExceptionCatcherVoter
      * @param \Exception $e
      *
      * @return bool
+     * @deprecated
      */
     public function shouldCatch(\Exception $e);
 }

--- a/src/Tolerance/Operation/ExceptionCatcher/ThrowableCatcherVoter.php
+++ b/src/Tolerance/Operation/ExceptionCatcher/ThrowableCatcherVoter.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Tolerance package.
+ *
+ * (c) Samuel ROZE <samuel.roze@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tolerance\Operation\ExceptionCatcher;
+
+/**
+ * Voter on Throwable errors
+ *
+ * This is extending ExceptionCatcherVoter for a BC layer. This extension should
+ * be removed as soon as the ExceptionCatcherVoter is removed.
+ *
+ * @author Baptiste Clavié <clavie.b@gmail.com>
+ */
+interface ThrowableCatcherVoter extends ExceptionCatcherVoter
+{
+    /**
+     * Decides if whatever we should catch the given throwable.
+     *
+     * There is no typehint, because \Throwable isn't available before PHP 7.0,
+     * so we need to handle \Exception too.
+     *
+     * @param \Exception|\Throwable $throwable
+     *
+     * @return bool
+     */
+    public function shouldCatchThrowable($throwable);
+}

--- a/src/Tolerance/Operation/ExceptionCatcher/WildcardExceptionVoter.php
+++ b/src/Tolerance/Operation/ExceptionCatcher/WildcardExceptionVoter.php
@@ -11,13 +11,21 @@
 
 namespace Tolerance\Operation\ExceptionCatcher;
 
-final class WildcardExceptionVoter implements ExceptionCatcherVoter
+final class WildcardExceptionVoter implements ThrowableCatcherVoter
 {
     /**
      * {@inheritdoc}
      */
     public function shouldCatch(\Exception $e)
     {
-        return true;
+        return $this->shouldCatchThrowable($e);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shouldCatchThrowable($throwable)
+    {
+        return $throwable instanceof \Throwable || $throwable instanceof \Exception;
     }
 }


### PR DESCRIPTION
In order to also catch `Throwable` in PHP7. I had to remove the typehint on the interface and the wildcard though (Not sure if this really count as a BC Break though, as it opens to actually everything...)