### PR TITLE
Add the stateful waiter

### DIFF
--- a/spec/Tolerance/Waiter/CountLimitedSpec.php
+++ b/spec/Tolerance/Waiter/CountLimitedSpec.php
@@ -3,6 +3,7 @@
 namespace spec\Tolerance\Waiter;
 
 use Tolerance\Waiter\Exception\CountLimitReached;
+use Tolerance\Waiter\StatefulWaiter;
 use Tolerance\Waiter\Waiter;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -18,6 +19,11 @@ class CountLimitedSpec extends ObjectBehavior
     function it_is_a_waiter()
     {
         $this->shouldHaveType(Waiter::class);
+    }
+
+    function it_is_a_stateful_waiter()
+    {
+        $this->shouldHaveType(StatefulWaiter::class);
     }
 
     function it_should_throw_directly_it_limit_is_zero(Waiter $waitStrategy)

--- a/spec/Tolerance/Waiter/ExponentialBackOffSpec.php
+++ b/spec/Tolerance/Waiter/ExponentialBackOffSpec.php
@@ -2,16 +2,25 @@
 
 namespace spec\Tolerance\Waiter;
 
+use Tolerance\Waiter\StatefulWaiter;
 use Tolerance\Waiter\Waiter;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class ExponentialBackOffSpec extends ObjectBehavior
 {
-    function it_waits_an_exponential_amount_of_time_each_time_its_called(Waiter $waiter)
+    function let(Waiter $waiter)
     {
         $this->beConstructedWith($waiter, 1);
+    }
 
+    function it_is_a_stateful_waiter()
+    {
+        $this->shouldHaveType(StatefulWaiter::class);
+    }
+
+    function it_waits_an_exponential_amount_of_time_each_time_its_called(Waiter $waiter)
+    {
         $waiter->wait(exp(1))->shouldBeCalled();
         $this->wait();
 

--- a/src/Tolerance/Operation/Runner/RetryOperationRunner.php
+++ b/src/Tolerance/Operation/Runner/RetryOperationRunner.php
@@ -15,6 +15,7 @@ use Tolerance\Operation\ExceptionCatcher\ExceptionCatcherVoter;
 use Tolerance\Operation\ExceptionCatcher\ThrowableCatcherVoter;
 use Tolerance\Operation\ExceptionCatcher\WildcardExceptionVoter;
 use Tolerance\Operation\Operation;
+use Tolerance\Waiter\StatefulWaiter;
 use Tolerance\Waiter\WaiterException;
 use Tolerance\Waiter\Waiter;
 
@@ -58,6 +59,10 @@ class RetryOperationRunner implements OperationRunner
      */
     public function run(Operation $operation)
     {
+        if ($this->waitStrategy instanceof StatefulWaiter) {
+            $this->waitStrategy->resetState();
+        }
+
         try {
             return $this->runner->run($operation);
         } catch (\Throwable $e) {

--- a/src/Tolerance/Waiter/CountLimited.php
+++ b/src/Tolerance/Waiter/CountLimited.php
@@ -13,7 +13,7 @@ namespace Tolerance\Waiter;
 
 use Tolerance\Waiter\Exception\CountLimitReached;
 
-class CountLimited implements Waiter
+class CountLimited implements Waiter, StatefulWaiter
 {
     /**
      * @var Waiter
@@ -23,16 +23,23 @@ class CountLimited implements Waiter
     /**
      * @var int
      */
-    private $limit;
+    private $initialLimit;
+
+    /**
+     * @var int
+     */
+    private $currentLimit;
 
     /**
      * @param Waiter $waiter
-     * @param int    $limit
+     * @param int    $initialLimit
      */
-    public function __construct(Waiter $waiter, $limit)
+    public function __construct(Waiter $waiter, $initialLimit)
     {
         $this->waiter = $waiter;
-        $this->limit = $limit;
+        $this->initialLimit = $initialLimit;
+
+        $this->resetState();
     }
 
     /**
@@ -40,10 +47,18 @@ class CountLimited implements Waiter
      */
     public function wait($seconds = 0)
     {
-        if ($this->limit-- <= 0) {
+        if ($this->currentLimit-- <= 0) {
             throw new CountLimitReached();
         }
 
         $this->waiter->wait($seconds);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resetState()
+    {
+        $this->currentLimit = $this->initialLimit;
     }
 }

--- a/src/Tolerance/Waiter/ExponentialBackOff.php
+++ b/src/Tolerance/Waiter/ExponentialBackOff.php
@@ -11,7 +11,7 @@
 
 namespace Tolerance\Waiter;
 
-class ExponentialBackOff implements Waiter
+class ExponentialBackOff implements Waiter, StatefulWaiter
 {
     /**
      * @var Waiter
@@ -21,16 +21,31 @@ class ExponentialBackOff implements Waiter
     /**
      * @var int
      */
-    private $exponent;
+    private $initialExponent;
+
+    /**
+     * @var int|null
+     */
+    private $currentExponent;
 
     /**
      * @param Waiter $waiter
-     * @param int    $exponent
+     * @param int    $initialExponent
      */
-    public function __construct(Waiter $waiter, $exponent)
+    public function __construct(Waiter $waiter, $initialExponent)
     {
-        $this->exponent = $exponent;
         $this->waiter = $waiter;
+        $this->initialExponent = $initialExponent;
+
+        $this->resetState();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resetState()
+    {
+        $this->currentExponent = $this->initialExponent;
     }
 
     /**
@@ -42,7 +57,7 @@ class ExponentialBackOff implements Waiter
 
         $this->waiter->wait($time);
 
-        $this->exponent++;
+        ++$this->currentExponent;
     }
 
     /**
@@ -54,7 +69,6 @@ class ExponentialBackOff implements Waiter
      */
     public function getNextTime($seconds = 0)
     {
-        return $seconds + exp($this->exponent);
+        return $seconds + exp($this->currentExponent);
     }
 }
-

--- a/src/Tolerance/Waiter/StatefulWaiter.php
+++ b/src/Tolerance/Waiter/StatefulWaiter.php
@@ -1,0 +1,30 @@
+<?php
+
+
+/*
+ * This file is part of the Tolerance package.
+ *
+ * (c) Samuel ROZE <samuel.roze@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tolerance\Waiter;
+
+/**
+ * This interface have to be implemented by waiters that contains state that change
+ * their behaviour.
+ *
+ * Whoever uses a same instance of the waiter many times should then call the `resetState`
+ * method before a "usage loop".
+ */
+interface StatefulWaiter extends Waiter
+{
+    /**
+     * Reset the state of the waiter to allow the reusability.
+     *
+     * @throws WaiterException
+     */
+    public function resetState();
+}


### PR DESCRIPTION
This adds a `StatefulWaiter` interface that needs to be implemented by all the waiters that contain state.

That way, when using a waiter, we can explicitly reset the state of it in order to reuse the same instance.