### PR TITLE
The buffered operation runner have to be run after the request ended listeners

### DIFF
--- a/src/Tolerance/Bridge/Symfony/Metrics/EventListener/RequestsEnds/DispatchRequestEndedEvent.php
+++ b/src/Tolerance/Bridge/Symfony/Metrics/EventListener/RequestsEnds/DispatchRequestEndedEvent.php
@@ -40,8 +40,8 @@ class DispatchRequestEndedEvent implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::TERMINATE => ['onTerminate', -255],
-            KernelEvents::EXCEPTION => ['onException', -255],
+            KernelEvents::TERMINATE => ['onTerminate', -10],
+            KernelEvents::EXCEPTION => ['onException', -10],
         ];
     }
 

--- a/src/Tolerance/Bridge/Symfony/Operation/RunBufferedOperationsWhenTerminates.php
+++ b/src/Tolerance/Bridge/Symfony/Operation/RunBufferedOperationsWhenTerminates.php
@@ -37,8 +37,8 @@ class RunBufferedOperationsWhenTerminates implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::TERMINATE => 'onTerminate',
-            ConsoleEvents::TERMINATE => 'onTerminate',
+            KernelEvents::TERMINATE => ['onTerminate', -25],
+            ConsoleEvents::TERMINATE => ['onTerminate', -25],
         ];
     }
 


### PR DESCRIPTION
The reason is that if a request end listener use something that is wrapped into a buffered runner, we'll have race conditions where these operation are not run...