### PR TITLE
The severity of the request do not having the start time is debug

### DIFF
--- a/src/Tolerance/Bridge/Symfony/Metrics/EventListener/RequestEnded/SendRequestTimeToPublisher.php
+++ b/src/Tolerance/Bridge/Symfony/Metrics/EventListener/RequestEnded/SendRequestTimeToPublisher.php
@@ -66,7 +66,7 @@ final class SendRequestTimeToPublisher implements EventSubscriberInterface
         $request = $event->getRequest();
 
         if (null === ($requestTime = $request->attributes->get('_tolerance_request_time', null))) {
-            $this->logger !== null && $this->logger->error('The request do not contain the start time');
+            $this->logger !== null && $this->logger->debug('The request do not contain the start time');
 
             return;
         }


### PR DESCRIPTION
We can't fight against [such listeners](https://github.com/nelmio/NelmioCorsBundle/blob/master/Resources/config/services.xml#L17) that are stopping the propagation of the requests.