### PR TITLE
[Guzzle] Rename retry option to retries

### DIFF
--- a/docs/bridges/symfony-bundle/guzzle.rst
+++ b/docs/bridges/symfony-bundle/guzzle.rst
@@ -16,7 +16,7 @@ Then you must enabled the bridge using the `guzzle` key:
     tolerance:
         guzzle: true
 
-Finally, just add the `retry` option in the configuration of your client:
+Finally, just add the `retries` option in the configuration of your client:
 
 .. code-block:: yaml
 
@@ -24,4 +24,4 @@ Finally, just add the `retry` option in the configuration of your client:
         clients:
             my_client:
                 config:
-                    retry: 2
+                    retries: 2

--- a/src/Tolerance/Bridge/Guzzle/Waiter/WaiterFactory.php
+++ b/src/Tolerance/Bridge/Guzzle/Waiter/WaiterFactory.php
@@ -20,11 +20,11 @@ use Tolerance\Waiter\SleepWaiter;
  */
 class WaiterFactory
 {
-    private $defaultRetry;
+    private $defaultRetries;
 
-    public function __construct($defaultRetry = 0)
+    public function __construct($defaultRetries = 0)
     {
-        $this->defaultRetry = (int) $defaultRetry;
+        $this->defaultRetries = (int) $defaultRetries;
     }
 
     public function __invoke($options)
@@ -34,7 +34,7 @@ class WaiterFactory
                 new SleepWaiter(),
                 1
             ),
-            isset($options['retry']) ? $options['retry'] : $this->defaultRetry
+            isset($options['retries']) ? $options['retries'] : $this->defaultRetries
         );
     }
 }

--- a/src/Tolerance/Operation/Runner/RetryPromiseOperationRunner.php
+++ b/src/Tolerance/Operation/Runner/RetryPromiseOperationRunner.php
@@ -79,7 +79,7 @@ class RetryPromiseOperationRunner implements OperationRunner
      *
      * @return mixed
      */
-    public function runOperation(PromiseOperation $operation)
+    private function runOperation(PromiseOperation $operation)
     {
         $promise = $operation->getPromise();
 
@@ -89,7 +89,7 @@ class RetryPromiseOperationRunner implements OperationRunner
         );
     }
 
-    protected function onTerminate(PromiseOperation $operation, ThrowableCatcherVoter $voter, $fulfilled, $promise)
+    private function onTerminate(PromiseOperation $operation, ThrowableCatcherVoter $voter, $fulfilled, $promise)
     {
         return function ($value) use ($operation, $voter, $fulfilled, $promise) {
             $exception = new PromiseException($value, $fulfilled);


### PR DESCRIPTION
It seems to be more standard:

http://docs.php-http.org/en/latest/plugins/retry.html
https://github.com/guzzle/guzzle/blob/master/src/RetryMiddleware.php#L63
