### PR TITLE
Add ability to configure timeout waiter

### DIFF
--- a/src/Tolerance/Bridge/Symfony/Bundle/ToleranceBundle/DependencyInjection/Configuration.php
+++ b/src/Tolerance/Bridge/Symfony/Bundle/ToleranceBundle/DependencyInjection/Configuration.php
@@ -177,6 +177,21 @@ class Configuration implements ConfigurationInterface
             $nodes[] = $exponentialNode;
         }
 
+        if (!in_array('timeout', $except)) {
+            $timeoutNode = $builder->root('timeout');
+            $strategyChildren = $timeoutNode
+                ->children()
+                ->integerNode('timeout')->isRequired()->end()
+                ->arrayNode('waiter')->isRequired()->children();
+
+            array_push($except, 'timeout');
+            foreach ($this->getWaiterNodes($except) as $node) {
+                $strategyChildren->append($node);
+            }
+
+            $nodes[] = $timeoutNode;
+        }
+
         if (!in_array('null', $except)) {
             $nodes[] = $builder->root('null');
         }

--- a/src/Tolerance/Bridge/Symfony/Bundle/ToleranceBundle/DependencyInjection/ToleranceExtension.php
+++ b/src/Tolerance/Bridge/Symfony/Bundle/ToleranceBundle/DependencyInjection/ToleranceExtension.php
@@ -43,6 +43,7 @@ use Tolerance\Waiter\ExponentialBackOff;
 use Tolerance\Waiter\CountLimited;
 use Tolerance\Waiter\NullWaiter;
 use Tolerance\Waiter\SleepWaiter;
+use Tolerance\Waiter\TimeOut;
 
 class ToleranceExtension extends Extension
 {
@@ -248,6 +249,8 @@ class ToleranceExtension extends Extension
             return $this->createSleepWaiterDefinition($container, $name);
         } elseif (array_key_exists('null', $config)) {
             return $this->createNullWaiterDefinition($container, $name);
+        } elseif (array_key_exists('timeout', $config)) {
+            return $this->createTimeoutWaiterDefinition($container, $name, $config['timeout']);
         }
 
         throw new \RuntimeException(sprintf(
@@ -290,6 +293,18 @@ class ToleranceExtension extends Extension
     private function createNullWaiterDefinition(ContainerBuilder $container, $name)
     {
         $container->setDefinition($name, new Definition(NullWaiter::class));
+
+        return $name;
+    }
+
+    private function createTimeoutWaiterDefinition(ContainerBuilder $container, $name, array $config)
+    {
+        $decoratedWaiterName = $this->createWaiterDefinition($container, $name.'.waiter', $config['waiter']);
+
+        $container->setDefinition($name, new Definition(TimeOut::class, [
+            new Reference($decoratedWaiterName),
+            $config['timeout']
+        ]));
 
         return $name;
     }

--- a/tests/Tolerance/Bridge/Symfony/Bundle/ToleranceBundle/DependencyInjection/ToleranceExtensionTest.php
+++ b/tests/Tolerance/Bridge/Symfony/Bundle/ToleranceBundle/DependencyInjection/ToleranceExtensionTest.php
@@ -132,6 +132,33 @@ class ToleranceExtensionTest extends \PHPUnit_Framework_TestCase
         ], $builder->reveal());
     }
 
+    public function test_it_registers_the_timeout_waiter_service()
+    {
+        $definitionArgument = Argument::type('Symfony\Component\DependencyInjection\Definition');
+
+        $builder = $this->createBuilder();
+        $builder->setDefinition(Argument::any(), $definitionArgument)->willReturn(null);
+        $builder->setDefinition('tolerance.operation_runners.foo.waiter', Argument::any())->shouldBeCalled();
+
+        $this->extension->load([
+            'tolerance' => [
+                'operation_runners' => [
+                    'foo' => [
+                        'retry' => [
+                            'runner' => ['callback' => null],
+                            'waiter' => [
+                                'timeout' => [
+                                    'waiter' => ['null' => null],
+                                    'timeout' => 60,
+                                ]
+                            ],
+                        ]
+                    ]
+                ],
+            ]
+        ], $builder->reveal());
+    }
+
     /**
      * @return \Symfony\Component\DependencyInjection\ContainerBuilder
      */


### PR DESCRIPTION
Change ToleranceBundle to allow set up timeout waiter from Symfony's application configuration.

Example:
```yaml
tolerance:
    operation_runners:
        foo:
            retry:
                runner:
                    callback: ~
                waiter:
                    timeout:
                        waiter:
                            null: ~
                        timeout: 60
```