### PR TITLE
Add detailled message exception when PromiseException is rejected

### DIFF
--- a/spec/Tolerance/Operation/Exception/PromiseExceptionSpec.php
+++ b/spec/Tolerance/Operation/Exception/PromiseExceptionSpec.php
@@ -3,16 +3,35 @@
 namespace spec\Tolerance\Operation\Exception;
 
 use PhpSpec\ObjectBehavior;
+use Psr\Http\Message\ResponseInterface;
 
 class PromiseExceptionSpec extends ObjectBehavior
 {
-    function let()
+    function it_should_be_an_exception()
     {
         $this->beConstructedWith('anything');
+        $this->shouldHaveType(\Exception::class);
     }
 
-    function it_should_be_an_operation()
+    function it_should_have_detailled_message_when_rejected_if_value_is_a_response(ResponseInterface $response)
     {
-        $this->shouldHaveType(\Exception::class);
+        $response->getStatusCode()->willReturn(504);
+        $response->getReasonPhrase()->willReturn('Timeout');
+        $this->beConstructedWith($response, false);
+        $this->getMessage()->shouldBeLike('Request resulted in a `504 Timeout` response');
+    }
+
+    function it_should_have_detailled_message_when_rejected_if_value_is_an_exception()
+    {
+        $exception = new \Exception('You fail');
+        $this->beConstructedWith($exception, false);
+        $this->getMessage()->shouldBeLike('You fail');
+    }
+
+    function it_should_have_previous_exception_when_rejected_if_value_is_an_exception()
+    {
+        $exception = new \Exception('You fail');
+        $this->beConstructedWith($exception, false);
+        $this->getPrevious()->shouldBeLike($exception);
     }
 }

--- a/src/Tolerance/Operation/Exception/PromiseException.php
+++ b/src/Tolerance/Operation/Exception/PromiseException.php
@@ -11,6 +11,8 @@
 
 namespace Tolerance\Operation\Exception;
 
+use Psr\Http\Message\ResponseInterface;
+
 class PromiseException extends \Exception
 {
     /**
@@ -27,6 +29,21 @@ class PromiseException extends \Exception
     {
         $this->value = $value;
         $this->fulfilled = $fulfilled;
+
+        if (false === $this->fulfilled) {
+            if ($value instanceof ResponseInterface) {
+                $message = sprintf(
+                    'Request resulted in a `%s %s` response',
+                    $value->getStatusCode(),
+                    $value->getReasonPhrase()
+                );
+            } elseif ($value instanceof \Exception) {
+                $message = $value->getMessage();
+                $previous = $value;
+            }
+
+            parent::__construct($message ?? null, 0, $previous ?? null);
+        }
     }
 
     /**


### PR DESCRIPTION
Currently, PromiseException message is empty even when rejected. Debugging or Logging could be a mess because you don't get original error.