### PR TITLE
Decapsulate PromiseException in php-http plugin

### DIFF
--- a/features/symfony/bootstrap/AopContext.php
+++ b/features/symfony/bootstrap/AopContext.php
@@ -52,6 +52,19 @@ class AopContext implements Context
     }
 
     /**
+     * @Given the 3rd party API will fail until the :nth run
+     */
+    public function theRdPartyApiWillFailUntilNthRun($nth)
+    {
+        $nbFail = substr($nth, 0, -2);
+        for ($i = 0; $i < $nbFail; ++$i) {
+            $this->stepByStepHookApiClient->registerStepHook($i, function () {
+                return new ApiException('That first step that fails');
+            });
+        }
+    }
+
+    /**
      * @When I call my local client service
      */
     public function iCallMyLocalClientService()
@@ -65,6 +78,16 @@ class AopContext implements Context
     public function iShouldSeeTheCallAsSuccessful()
     {
         if ($this->response != 'The good API answer') {
+            throw new \RuntimeException('The found answer is not matching the expected one');
+        }
+    }
+
+    /**
+     * @Then I should see the call as error
+     */
+    public function iShouldSeeTheCallAsError()
+    {
+        if (false === $this->response instanceof ApiException) {
             throw new \RuntimeException('The found answer is not matching the expected one');
         }
     }

--- a/features/symfony/retry.feature
+++ b/features/symfony/retry.feature
@@ -4,8 +4,14 @@ Feature:
   I want to be able to only add a tag in the Symfony DIC
 
   @aop @php_http
-  Scenario: Uses a retry operation runner
+  Scenario: Uses a retry operation runner with successful run
     Given the 3rd party API will fail at the 1st run
     And the 3rd party API will succeed at the 2nd run
     When I call my local client service
     Then I should see the call as successful
+
+  @php_http
+  Scenario: Uses a retry operation runner without successful run
+    Given the 3rd party API will fail until the 10th run
+    When I call my local client service
+    Then I should see the call as error


### PR DESCRIPTION
We did it for Guzzle in RetryPromiseOperationRunner but as PhpHttp does not support async Promise we should do it in the plugin for PhpHttp